### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "javascriptSol/index.js"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # LeetCodeSolutions
 Solutions to leet code code problems
+[![Run on Repl.it](https://repl.it/badge/github/webor/LeetCodeSolutions)](https://repl.it/github/webor/LeetCodeSolutions)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@vibhortambat/LeetCodeSolutions).